### PR TITLE
Centered Session Time TextView

### DIFF
--- a/android/app/src/main/res/layout/item_session.xml
+++ b/android/app/src/main/res/layout/item_session.xml
@@ -10,7 +10,7 @@
         android:id="@+id/timeslot"
         android:layout_width="@dimen/timeslot_width"
         android:layout_height="wrap_content"
-        android:layout_marginTop="8dp"
+        android:layout_marginTop="18dp"
         android:gravity="end"
         tools:text="12:00 PM\nto\n12:45pm"/>
 


### PR DESCRIPTION
The Sessions List Items had their Session Times TextView Aligned correctly on the same grid as the CardView title in the Session ListView, but because of how TextViews draw the characters within the canvas of their views, the text of the Timeslots and the CardView's Title were not optically centered. Meaning, to the human eye, the text of the Timeslot appeared above the gridline of the text of the CardView Title.

I eyeballed this dp increase of the top margin for now.
A possible better solution in the future could be to rewrite the layout using `ConstraintLayout` to align based on TextView baselines, instead of eyeballing how many `dps` to do a `marginTop` with.