### PR TITLE
show times in Chicago time, not the phone's local time

### DIFF
--- a/android/app/src/main/kotlin/com/chicagoroboto/data/DataModule.kt
+++ b/android/app/src/main/kotlin/com/chicagoroboto/data/DataModule.kt
@@ -41,6 +41,10 @@ class DataModule {
         return FirebaseStorage.getInstance().reference.child(eventId)
     }
 
+    @Provides @Singleton fun provideConfigProvider(db: DatabaseReference): ConfigProvider {
+        return FirebaseConfigProvider(db)
+    }
+
     @Provides @Singleton fun provideSessionDateProvider(db: DatabaseReference): SessionDateProvider {
         return FirebaseSessionDateProvider(db)
     }

--- a/android/app/src/main/kotlin/com/chicagoroboto/data/FirebaseConfigProvider.kt
+++ b/android/app/src/main/kotlin/com/chicagoroboto/data/FirebaseConfigProvider.kt
@@ -1,0 +1,26 @@
+package com.chicagoroboto.data
+
+import com.google.firebase.database.DataSnapshot
+import com.google.firebase.database.DatabaseError
+import com.google.firebase.database.DatabaseReference
+import com.google.firebase.database.ValueEventListener
+
+class FirebaseConfigProvider(db: DatabaseReference) : ConfigProvider {
+
+    private val ref = db.child("config")
+
+    override fun getTimezoneName(callback: (String) -> Unit) {
+        val listener = object : ValueEventListener {
+            override fun onDataChange(data: DataSnapshot?) {
+                callback(data!!.getValue(String::class.java)!!)
+            }
+
+            override fun onCancelled(error: DatabaseError?) {
+                // oh noes
+            }
+        }
+        val query = ref.child("event-timezone")
+        query.addListenerForSingleValueEvent(listener)
+    }
+
+}

--- a/android/app/src/main/kotlin/com/chicagoroboto/features/sessiondetail/SessionDetailView.kt
+++ b/android/app/src/main/kotlin/com/chicagoroboto/features/sessiondetail/SessionDetailView.kt
@@ -4,7 +4,6 @@ import android.app.Activity
 import android.content.Context
 import android.support.design.widget.CoordinatorLayout
 import android.support.v7.widget.LinearLayoutManager
-import android.text.format.DateUtils
 import android.util.AttributeSet
 import android.view.LayoutInflater
 import com.chicagoroboto.R
@@ -15,6 +14,7 @@ import com.chicagoroboto.features.speakerdetail.SpeakerNavigator
 import com.chicagoroboto.model.Session
 import com.chicagoroboto.model.Speaker
 import com.chicagoroboto.utils.DrawableUtils
+import com.chicagoroboto.utils.getFormattedSessionTime
 import kotlinx.android.synthetic.main.view_session_detail.view.*
 import java.util.Date
 import javax.inject.Inject
@@ -73,10 +73,8 @@ class SessionDetailView(context: Context, attrs: AttributeSet? = null, defStyle:
     override fun showSessionDetail(session: Session) {
         toolbar.title = session.title
 
-        val startTime = DateUtils.formatDateTime(context, session.startTime?.time ?: 0,
-            DateUtils.FORMAT_SHOW_TIME)
-        val endTime = DateUtils.formatDateTime(context, session.endTime?.time ?: 0,
-            DateUtils.FORMAT_SHOW_TIME)
+        val startTime = getFormattedSessionTime(session.startTime)
+        val endTime = getFormattedSessionTime(session.endTime)
         banner.text = String.format(context.getString(R.string.session_detail_time), session.room,
             startTime, endTime)
 

--- a/android/app/src/main/kotlin/com/chicagoroboto/features/sessions/SessionAdapter.kt
+++ b/android/app/src/main/kotlin/com/chicagoroboto/features/sessions/SessionAdapter.kt
@@ -3,8 +3,6 @@ package com.chicagoroboto.features.sessions
 import android.support.v4.content.ContextCompat
 import android.support.v7.widget.CardView
 import android.support.v7.widget.RecyclerView
-import android.text.format.DateUtils
-import android.text.format.DateUtils.formatDateTime
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -14,6 +12,7 @@ import com.chicagoroboto.R
 import com.chicagoroboto.model.Session
 import com.chicagoroboto.model.Speaker
 import com.chicagoroboto.utils.DrawableUtils
+import com.chicagoroboto.utils.getFormattedSessionTime
 import kotlinx.android.synthetic.main.item_session.view.*
 import java.util.Date
 
@@ -35,11 +34,11 @@ internal class SessionAdapter(val onSessionSelectedListener: ((session: Session)
 
         holder.session = session
 
-        val startTime = formatDateTime(context, session.startTime?.time ?: 0, DateUtils.FORMAT_SHOW_TIME)
-        val endTime = formatDateTime(context, session.endTime?.time ?: 0, DateUtils.FORMAT_SHOW_TIME)
+        var startTime = getFormattedSessionTime(session.startTime)
+        var endTime = getFormattedSessionTime(session.endTime)
         holder.timeslot.text = String.format(context.getString(R.string.session_time), startTime, endTime)
 
-        // Dim the session card once hte session is over
+        // Dim the session card once the session is over
         val now = Date()
         if (now.before(session.endTime)) {
             holder.card.setBackgroundColor(ContextCompat.getColor(context, R.color.session_bg))

--- a/android/app/src/main/kotlin/com/chicagoroboto/utils/RobotoDateUtils.kt
+++ b/android/app/src/main/kotlin/com/chicagoroboto/utils/RobotoDateUtils.kt
@@ -1,0 +1,10 @@
+package com.chicagoroboto.utils
+
+import java.text.SimpleDateFormat
+import java.util.*
+
+fun getFormattedSessionTime(sessionTime: Date?): String {
+    var sdf = SimpleDateFormat("HH:mm a")
+    sdf.timeZone = TimeZone.getTimeZone("America/Chicago")
+    return sdf.format(sessionTime)
+}

--- a/android/app/src/main/kotlin/com/chicagoroboto/utils/RobotoDateUtils.kt
+++ b/android/app/src/main/kotlin/com/chicagoroboto/utils/RobotoDateUtils.kt
@@ -3,13 +3,13 @@ package com.chicagoroboto.utils
 import java.text.SimpleDateFormat
 import java.util.*
 
-fun getFormattedSessionTime(sessionTime: Date?): String {
+fun getFormattedSessionTime(sessionTime: Date?, timezoneName: String): String {
     if (sessionTime == null) {
         return "null"
     }
     else {
         var sdf = SimpleDateFormat("HH:mm a")
-        sdf.timeZone = TimeZone.getTimeZone("America/Chicago")
+        sdf.timeZone = TimeZone.getTimeZone(timezoneName)
         return sdf.format(sessionTime)
     }
 }

--- a/android/app/src/main/kotlin/com/chicagoroboto/utils/RobotoDateUtils.kt
+++ b/android/app/src/main/kotlin/com/chicagoroboto/utils/RobotoDateUtils.kt
@@ -4,7 +4,12 @@ import java.text.SimpleDateFormat
 import java.util.*
 
 fun getFormattedSessionTime(sessionTime: Date?): String {
-    var sdf = SimpleDateFormat("HH:mm a")
-    sdf.timeZone = TimeZone.getTimeZone("America/Chicago")
-    return sdf.format(sessionTime)
+    if (sessionTime == null) {
+        return "null"
+    }
+    else {
+        var sdf = SimpleDateFormat("HH:mm a")
+        sdf.timeZone = TimeZone.getTimeZone("America/Chicago")
+        return sdf.format(sessionTime)
+    }
 }

--- a/android/core/src/main/kotlin/com/chicagoroboto/data/ConfigProvider.kt
+++ b/android/core/src/main/kotlin/com/chicagoroboto/data/ConfigProvider.kt
@@ -1,0 +1,5 @@
+package com.chicagoroboto.data
+
+interface ConfigProvider {
+    fun getTimezoneName(callback: (String) -> Unit)
+}


### PR DESCRIPTION
When I opened the app yesterday from Indianapolis, I thought the first talk was 10AM because the times were formatted with `DateUtils.formatDateTime()` which uses the device's current time zone. I wrote a small package private function to format using a SimpleDateFormat. Happy to use Joda or threeTenABP if you prefer.[](url)