### PR TITLE
Animate cells

### DIFF
--- a/android/app/src/main/kotlin/com/chicagoroboto/features/sessiondetail/SpeakerAdapter.kt
+++ b/android/app/src/main/kotlin/com/chicagoroboto/features/sessiondetail/SpeakerAdapter.kt
@@ -22,7 +22,6 @@ internal class SpeakerAdapter(private val avatarProvider: AvatarProvider,
     val speakers: MutableList<Speaker> = mutableListOf()
 
     init {
-        animationDuration = 500
         showAnimation = true
     }
 

--- a/android/app/src/main/kotlin/com/chicagoroboto/features/sessiondetail/SpeakerAdapter.kt
+++ b/android/app/src/main/kotlin/com/chicagoroboto/features/sessiondetail/SpeakerAdapter.kt
@@ -22,8 +22,8 @@ internal class SpeakerAdapter(private val avatarProvider: AvatarProvider,
     val speakers: MutableList<Speaker> = mutableListOf()
 
     init {
-        mAnimationDuration = 500
-        mShowAnimation = true
+        animationDuration = 500
+        showAnimation = true
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {

--- a/android/app/src/main/kotlin/com/chicagoroboto/features/sessiondetail/SpeakerAdapter.kt
+++ b/android/app/src/main/kotlin/com/chicagoroboto/features/sessiondetail/SpeakerAdapter.kt
@@ -4,6 +4,7 @@ import android.support.v7.widget.RecyclerView
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.animation.AnimationUtils
 import android.widget.ImageView
 import android.widget.TextView
 import com.bumptech.glide.Glide
@@ -18,6 +19,8 @@ internal class SpeakerAdapter(private val avatarProvider: AvatarProvider,
                               val onSpeakerClickedListener: ((speaker: Speaker, view: View) -> Unit)) :
         RecyclerView.Adapter<SpeakerAdapter.ViewHolder>() {
 
+    private var mLastPosition = -1
+
     val speakers: MutableList<Speaker> = mutableListOf()
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
@@ -30,6 +33,18 @@ internal class SpeakerAdapter(private val avatarProvider: AvatarProvider,
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
         holder.bind(speakers[position])
+
+        mLastPosition = setAnimation(holder.itemView, position, mLastPosition)
+    }
+
+    private fun setAnimation(view: View, position: Int, lastPosition: Int) : Int {
+        var newPosition = lastPosition
+        if(position > lastPosition) {
+            val animation = AnimationUtils.loadAnimation(view.context, android.R.anim.slide_in_left)
+            view.startAnimation(animation)
+            newPosition = position
+        }
+        return newPosition
     }
 
     override fun getItemCount(): Int {

--- a/android/app/src/main/kotlin/com/chicagoroboto/features/sessiondetail/SpeakerAdapter.kt
+++ b/android/app/src/main/kotlin/com/chicagoroboto/features/sessiondetail/SpeakerAdapter.kt
@@ -35,6 +35,7 @@ internal class SpeakerAdapter(private val avatarProvider: AvatarProvider,
     }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        // Call super to play animation
         super.onBindViewHolder(holder, position)
 
         holder.bind(speakers[position])

--- a/android/app/src/main/kotlin/com/chicagoroboto/features/sessiondetail/SpeakerAdapter.kt
+++ b/android/app/src/main/kotlin/com/chicagoroboto/features/sessiondetail/SpeakerAdapter.kt
@@ -4,24 +4,27 @@ import android.support.v7.widget.RecyclerView
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.view.animation.AnimationUtils
 import android.widget.ImageView
 import android.widget.TextView
 import com.bumptech.glide.Glide
 import com.chicagoroboto.R
 import com.chicagoroboto.data.AvatarProvider
 import com.chicagoroboto.model.Speaker
+import com.chicagoroboto.utils.ChicagoRobotoAdapter
 import com.chicagoroboto.utils.DrawableUtils
 import kotlinx.android.synthetic.main.item_speaker.view.*
 
 internal class SpeakerAdapter(private val avatarProvider: AvatarProvider,
-                              val wrapsWidth: Boolean = true,
-                              val onSpeakerClickedListener: ((speaker: Speaker, view: View) -> Unit)) :
-        RecyclerView.Adapter<SpeakerAdapter.ViewHolder>() {
-
-    private var mLastPosition = -1
+                              private val wrapsWidth: Boolean = true,
+                              private val onSpeakerClickedListener: ((speaker: Speaker, view: View) -> Unit)) :
+        ChicagoRobotoAdapter<SpeakerAdapter.ViewHolder>() {
 
     val speakers: MutableList<Speaker> = mutableListOf()
+
+    init {
+        mAnimationDuration = 500
+        mShowAnimation = true
+    }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
         val v = LayoutInflater.from(parent.context).inflate(R.layout.item_speaker, parent, false)
@@ -32,19 +35,9 @@ internal class SpeakerAdapter(private val avatarProvider: AvatarProvider,
     }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        super.onBindViewHolder(holder, position)
+
         holder.bind(speakers[position])
-
-        mLastPosition = setAnimation(holder.itemView, position, mLastPosition)
-    }
-
-    private fun setAnimation(view: View, position: Int, lastPosition: Int) : Int {
-        var newPosition = lastPosition
-        if(position > lastPosition) {
-            val animation = AnimationUtils.loadAnimation(view.context, android.R.anim.slide_in_left)
-            view.startAnimation(animation)
-            newPosition = position
-        }
-        return newPosition
     }
 
     override fun getItemCount(): Int {

--- a/android/app/src/main/kotlin/com/chicagoroboto/features/sessions/SessionAdapter.kt
+++ b/android/app/src/main/kotlin/com/chicagoroboto/features/sessions/SessionAdapter.kt
@@ -27,7 +27,7 @@ internal class SessionAdapter(val onSessionSelectedListener: ((session: Session)
     val favorites: MutableSet<String> = mutableSetOf()
 
     init {
-        animationDuration = 500
+        staggerAnimation = true
         showAnimation = true
     }
 

--- a/android/app/src/main/kotlin/com/chicagoroboto/features/sessions/SessionAdapter.kt
+++ b/android/app/src/main/kotlin/com/chicagoroboto/features/sessions/SessionAdapter.kt
@@ -27,8 +27,8 @@ internal class SessionAdapter(val onSessionSelectedListener: ((session: Session)
     val favorites: MutableSet<String> = mutableSetOf()
 
     init {
-        mAnimationDuration = 500
-        mShowAnimation = true
+        animationDuration = 500
+        showAnimation = true
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {

--- a/android/app/src/main/kotlin/com/chicagoroboto/features/sessions/SessionAdapter.kt
+++ b/android/app/src/main/kotlin/com/chicagoroboto/features/sessions/SessionAdapter.kt
@@ -8,6 +8,7 @@ import android.text.format.DateUtils.formatDateTime
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.animation.AnimationUtils
 import android.widget.ImageView
 import android.widget.TextView
 import com.chicagoroboto.R
@@ -23,6 +24,8 @@ internal class SessionAdapter(val onSessionSelectedListener: ((session: Session)
     val sessions: MutableList<Session> = mutableListOf()
     val speakers: MutableMap<String, Speaker> = mutableMapOf()
     val favorites: MutableSet<String> = mutableSetOf()
+
+    var mLastPosition = -1
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
         val view = LayoutInflater.from(parent.context).inflate(R.layout.item_session, parent, false)
@@ -90,6 +93,19 @@ internal class SessionAdapter(val onSessionSelectedListener: ((session: Session)
         } else {
             holder.timeslot.visibility = View.VISIBLE
         }
+
+        mLastPosition = setAnimation(holder.itemView, position, mLastPosition)
+    }
+
+    private fun setAnimation(view: View, position: Int, lastPosition: Int) : Int {
+        var newPosition = lastPosition
+        if(position > lastPosition) {
+            val animation = AnimationUtils.loadAnimation(view.context, android.R.anim.slide_in_left)
+            animation.duration = 1500
+            view.startAnimation(animation)
+            newPosition = position
+        }
+        return newPosition
     }
 
     override fun getItemCount(): Int {

--- a/android/app/src/main/kotlin/com/chicagoroboto/features/sessions/SessionAdapter.kt
+++ b/android/app/src/main/kotlin/com/chicagoroboto/features/sessions/SessionAdapter.kt
@@ -37,6 +37,7 @@ internal class SessionAdapter(val onSessionSelectedListener: ((session: Session)
     }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        // Call super to play animation
         super.onBindViewHolder(holder, position)
 
         val context = holder.itemView.context

--- a/android/app/src/main/kotlin/com/chicagoroboto/features/sessions/SessionAdapter.kt
+++ b/android/app/src/main/kotlin/com/chicagoroboto/features/sessions/SessionAdapter.kt
@@ -8,24 +8,28 @@ import android.text.format.DateUtils.formatDateTime
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.view.animation.AnimationUtils
 import android.widget.ImageView
 import android.widget.TextView
 import com.chicagoroboto.R
 import com.chicagoroboto.model.Session
 import com.chicagoroboto.model.Speaker
+import com.chicagoroboto.utils.ChicagoRobotoAdapter
 import com.chicagoroboto.utils.DrawableUtils
 import kotlinx.android.synthetic.main.item_session.view.*
 import java.util.Date
 
 internal class SessionAdapter(val onSessionSelectedListener: ((session: Session) -> Unit)) :
-        RecyclerView.Adapter<SessionAdapter.ViewHolder>() {
+        ChicagoRobotoAdapter<SessionAdapter.ViewHolder>()
+        {
 
     val sessions: MutableList<Session> = mutableListOf()
     val speakers: MutableMap<String, Speaker> = mutableMapOf()
     val favorites: MutableSet<String> = mutableSetOf()
 
-    var mLastPosition = -1
+    init {
+        mAnimationDuration = 500
+        mShowAnimation = true
+    }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
         val view = LayoutInflater.from(parent.context).inflate(R.layout.item_session, parent, false)
@@ -33,6 +37,8 @@ internal class SessionAdapter(val onSessionSelectedListener: ((session: Session)
     }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        super.onBindViewHolder(holder, position)
+
         val context = holder.itemView.context
         val session = sessions[position]
 
@@ -94,18 +100,6 @@ internal class SessionAdapter(val onSessionSelectedListener: ((session: Session)
             holder.timeslot.visibility = View.VISIBLE
         }
 
-        mLastPosition = setAnimation(holder.itemView, position, mLastPosition)
-    }
-
-    private fun setAnimation(view: View, position: Int, lastPosition: Int) : Int {
-        var newPosition = lastPosition
-        if(position > lastPosition) {
-            val animation = AnimationUtils.loadAnimation(view.context, android.R.anim.slide_in_left)
-            animation.duration = 1500
-            view.startAnimation(animation)
-            newPosition = position
-        }
-        return newPosition
     }
 
     override fun getItemCount(): Int {

--- a/android/app/src/main/kotlin/com/chicagoroboto/utils/ChicagoRobotoAdapter.kt
+++ b/android/app/src/main/kotlin/com/chicagoroboto/utils/ChicagoRobotoAdapter.kt
@@ -18,7 +18,9 @@ open class ChicagoRobotoAdapter<T: RecyclerView.ViewHolder>(private var mLastPos
     }
 
     /**
-     * These won't be used, but will be implemented by child adapter classes
+     * These won't be used, but will be implemented by child adapter classes.
+     * There's currently no worry on the TODOs getting hit at runtime but if children ever call it
+     * the app can crash.
      */
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): T {
         TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
@@ -28,16 +30,21 @@ open class ChicagoRobotoAdapter<T: RecyclerView.ViewHolder>(private var mLastPos
         TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
     }
 
+    /**
+     * Play the animation
+     */
     override fun onBindViewHolder(holder: T, position: Int) {
-        setAnimation(holder.itemView, position)
+        if(mShowAnimation) {
+            setAnimation(holder.itemView, position)
+        }
     }
 
     /**
      * Shows an animation on the cell
      * Reference: https://stackoverflow.com/questions/26724964/how-to-animate-recyclerview-items-when-they-appear
      */
-    protected fun setAnimation(view: View, position: Int) {
-        if(mShowAnimation && (position > mLastPosition)) {
+    private fun setAnimation(view: View, position: Int) {
+        if(position > mLastPosition) {
             val animation = AnimationUtils.loadAnimation(view.context, android.R.anim.slide_in_left)
             animation.duration = mAnimationDuration
             view.startAnimation(animation)

--- a/android/app/src/main/kotlin/com/chicagoroboto/utils/ChicagoRobotoAdapter.kt
+++ b/android/app/src/main/kotlin/com/chicagoroboto/utils/ChicagoRobotoAdapter.kt
@@ -9,6 +9,7 @@ import android.view.animation.AnimationUtils
  * Adapter base class to optionally add animations to the view items
  */
 open class ChicagoRobotoAdapter<T: RecyclerView.ViewHolder>(private var mLastPosition:Int = -1,
+                                                            var mAnimationType:Int = android.R.anim.slide_in_left,
                                                             var mAnimationDuration:Long = ANIMATION_DURATION,
                                                             var mShowAnimation:Boolean = true) :
         RecyclerView.Adapter<T>() {
@@ -45,7 +46,7 @@ open class ChicagoRobotoAdapter<T: RecyclerView.ViewHolder>(private var mLastPos
      */
     private fun setAnimation(view: View, position: Int) {
         if(position > mLastPosition) {
-            val animation = AnimationUtils.loadAnimation(view.context, android.R.anim.slide_in_left)
+            val animation = AnimationUtils.loadAnimation(view.context, mAnimationType)
             animation.duration = mAnimationDuration
             view.startAnimation(animation)
             mLastPosition = position

--- a/android/app/src/main/kotlin/com/chicagoroboto/utils/ChicagoRobotoAdapter.kt
+++ b/android/app/src/main/kotlin/com/chicagoroboto/utils/ChicagoRobotoAdapter.kt
@@ -9,8 +9,7 @@ import kotlin.math.absoluteValue
 /**
  * Adapter base class to optionally add animations to the view items
  */
-abstract class ChicagoRobotoAdapter<T: RecyclerView.ViewHolder>(private var lastPosition:Int = -1,
-                                                            var staggerAnimation:Boolean = false,
+abstract class ChicagoRobotoAdapter<T: RecyclerView.ViewHolder>(var staggerAnimation:Boolean = false,
                                                             var animationDuration:Long = 300,
                                                             var showAnimation:Boolean = false) :
         RecyclerView.Adapter<T>() {
@@ -40,23 +39,18 @@ abstract class ChicagoRobotoAdapter<T: RecyclerView.ViewHolder>(private var last
      * Shows an animation on the cell
      */
     private fun setAnimation(view: View, position: Int) {
-        if(position > lastPosition) {
+        // Start the view out of the screen to the left
+        view.x = (-view.width).toFloat()
+        view.visibility = View.VISIBLE
 
-            val oldX = view.x
-            view.x = (-view.width).toFloat()
-            view.visibility = View.VISIBLE
+        // Animate slide to original position
+        val objectAnimator = ObjectAnimator.ofFloat(view, "translationX", 0f)
 
-            // Animate slide to original position
-            val objectAnimator = ObjectAnimator.ofFloat(view, "translationX", oldX)
-
-            // Stagger effect
-            if(staggerAnimation) {
-                objectAnimator.duration = animationDuration + (lastPosition * STAGGER_FACTOR).absoluteValue
-            }
-
-            objectAnimator.start()
-
-            lastPosition = position
+        // Stagger effect
+        if(staggerAnimation) {
+            objectAnimator.duration = animationDuration + (position * STAGGER_FACTOR).absoluteValue
         }
+
+        objectAnimator.start()
     }
 }

--- a/android/app/src/main/kotlin/com/chicagoroboto/utils/ChicagoRobotoAdapter.kt
+++ b/android/app/src/main/kotlin/com/chicagoroboto/utils/ChicagoRobotoAdapter.kt
@@ -1,17 +1,18 @@
 package com.chicagoroboto.utils
 
+import android.animation.ObjectAnimator
 import android.support.annotation.CallSuper
 import android.support.v7.widget.RecyclerView
 import android.view.View
-import android.view.animation.AnimationUtils
+import kotlin.math.absoluteValue
 
 /**
  * Adapter base class to optionally add animations to the view items
  */
 abstract class ChicagoRobotoAdapter<T: RecyclerView.ViewHolder>(private var lastPosition:Int = -1,
-                                                            var animationType:Int = android.R.anim.slide_in_left,
-                                                            var animationDuration:Long = 1000,
-                                                            var showAnimation:Boolean = true) :
+                                                            var staggerAnimation:Boolean = false,
+                                                            var animationDuration:Long = 300,
+                                                            var showAnimation:Boolean = false) :
         RecyclerView.Adapter<T>() {
 
     /**
@@ -30,9 +31,18 @@ abstract class ChicagoRobotoAdapter<T: RecyclerView.ViewHolder>(private var last
      */
     private fun setAnimation(view: View, position: Int) {
         if(position > lastPosition) {
-            val animation = AnimationUtils.loadAnimation(view.context, animationType)
-            animation.duration = animationDuration
-            view.startAnimation(animation)
+
+            val oldX = view.x
+            view.x = -(view.width + 1000).toFloat()
+            val objectAnimator = ObjectAnimator.ofFloat(view, "translationX", oldX)
+
+            // Stagger effect
+            if(staggerAnimation) {
+                objectAnimator.duration = animationDuration + (lastPosition * 100).absoluteValue
+            }
+
+            objectAnimator.start()
+
             lastPosition = position
         }
     }

--- a/android/app/src/main/kotlin/com/chicagoroboto/utils/ChicagoRobotoAdapter.kt
+++ b/android/app/src/main/kotlin/com/chicagoroboto/utils/ChicagoRobotoAdapter.kt
@@ -1,41 +1,25 @@
 package com.chicagoroboto.utils
 
+import android.support.annotation.CallSuper
 import android.support.v7.widget.RecyclerView
 import android.view.View
-import android.view.ViewGroup
 import android.view.animation.AnimationUtils
 
 /**
  * Adapter base class to optionally add animations to the view items
  */
-open class ChicagoRobotoAdapter<T: RecyclerView.ViewHolder>(private var mLastPosition:Int = -1,
-                                                            var mAnimationType:Int = android.R.anim.slide_in_left,
-                                                            var mAnimationDuration:Long = ANIMATION_DURATION,
-                                                            var mShowAnimation:Boolean = true) :
+abstract class ChicagoRobotoAdapter<T: RecyclerView.ViewHolder>(private var lastPosition:Int = -1,
+                                                            var animationType:Int = android.R.anim.slide_in_left,
+                                                            var animationDuration:Long = 1000,
+                                                            var showAnimation:Boolean = true) :
         RecyclerView.Adapter<T>() {
 
-    companion object {
-        const val ANIMATION_DURATION: Long = 1000
-    }
-
     /**
-     * These won't be used, but will be implemented by child adapter classes.
-     * There's currently no worry on the TODOs getting hit at runtime but if children ever call it
-     * the app can crash.
+     * Play the animation if enabled
      */
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): T {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
-    }
-
-    override fun getItemCount(): Int {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
-    }
-
-    /**
-     * Play the animation
-     */
+    @CallSuper
     override fun onBindViewHolder(holder: T, position: Int) {
-        if(mShowAnimation) {
+        if(showAnimation) {
             setAnimation(holder.itemView, position)
         }
     }
@@ -45,11 +29,11 @@ open class ChicagoRobotoAdapter<T: RecyclerView.ViewHolder>(private var mLastPos
      * Reference: https://stackoverflow.com/questions/26724964/how-to-animate-recyclerview-items-when-they-appear
      */
     private fun setAnimation(view: View, position: Int) {
-        if(position > mLastPosition) {
-            val animation = AnimationUtils.loadAnimation(view.context, mAnimationType)
-            animation.duration = mAnimationDuration
+        if(position > lastPosition) {
+            val animation = AnimationUtils.loadAnimation(view.context, animationType)
+            animation.duration = animationDuration
             view.startAnimation(animation)
-            mLastPosition = position
+            lastPosition = position
         }
     }
 }

--- a/android/app/src/main/kotlin/com/chicagoroboto/utils/ChicagoRobotoAdapter.kt
+++ b/android/app/src/main/kotlin/com/chicagoroboto/utils/ChicagoRobotoAdapter.kt
@@ -15,30 +15,43 @@ abstract class ChicagoRobotoAdapter<T: RecyclerView.ViewHolder>(private var last
                                                             var showAnimation:Boolean = false) :
         RecyclerView.Adapter<T>() {
 
+    companion object {
+        val STAGGER_FACTOR = 100
+    }
+
     /**
      * Play the animation if enabled
      */
     @CallSuper
     override fun onBindViewHolder(holder: T, position: Int) {
         if(showAnimation) {
-            setAnimation(holder.itemView, position)
+            // Set invisible, initially
+            holder.itemView.visibility = View.INVISIBLE
+
+            // Post so the item has width, which will be used
+            holder.itemView.post({
+                setAnimation(holder.itemView, position)
+            })
+
         }
     }
 
     /**
      * Shows an animation on the cell
-     * Reference: https://stackoverflow.com/questions/26724964/how-to-animate-recyclerview-items-when-they-appear
      */
     private fun setAnimation(view: View, position: Int) {
         if(position > lastPosition) {
 
             val oldX = view.x
-            view.x = -(view.width + 1000).toFloat()
+            view.x = (-view.width).toFloat()
+            view.visibility = View.VISIBLE
+
+            // Animate slide to original position
             val objectAnimator = ObjectAnimator.ofFloat(view, "translationX", oldX)
 
             // Stagger effect
             if(staggerAnimation) {
-                objectAnimator.duration = animationDuration + (lastPosition * 100).absoluteValue
+                objectAnimator.duration = animationDuration + (lastPosition * STAGGER_FACTOR).absoluteValue
             }
 
             objectAnimator.start()

--- a/android/app/src/main/kotlin/com/chicagoroboto/utils/ChicagoRobotoAdapter.kt
+++ b/android/app/src/main/kotlin/com/chicagoroboto/utils/ChicagoRobotoAdapter.kt
@@ -1,0 +1,47 @@
+package com.chicagoroboto.utils
+
+import android.support.v7.widget.RecyclerView
+import android.view.View
+import android.view.ViewGroup
+import android.view.animation.AnimationUtils
+
+/**
+ * Adapter base class to optionally add animations to the view items
+ */
+open class ChicagoRobotoAdapter<T: RecyclerView.ViewHolder>(private var mLastPosition:Int = -1,
+                                                            var mAnimationDuration:Long = ANIMATION_DURATION,
+                                                            var mShowAnimation:Boolean = true) :
+        RecyclerView.Adapter<T>() {
+
+    companion object {
+        const val ANIMATION_DURATION: Long = 1000
+    }
+
+    /**
+     * These won't be used, but will be implemented by child adapter classes
+     */
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): T {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun getItemCount(): Int {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun onBindViewHolder(holder: T, position: Int) {
+        setAnimation(holder.itemView, position)
+    }
+
+    /**
+     * Shows an animation on the cell
+     * Reference: https://stackoverflow.com/questions/26724964/how-to-animate-recyclerview-items-when-they-appear
+     */
+    protected fun setAnimation(view: View, position: Int) {
+        if(mShowAnimation && (position > mLastPosition)) {
+            val animation = AnimationUtils.loadAnimation(view.context, android.R.anim.slide_in_left)
+            animation.duration = mAnimationDuration
+            view.startAnimation(animation)
+            mLastPosition = position
+        }
+    }
+}

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@
 apply from: 'dependencies.gradle'
 
 buildscript {
-  ext.kotlin_version = '1.2.30'
+  ext.kotlin_version = '1.2.31'
 
   repositories {
     google()

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     maven { url "https://dl.bintray.com/kotlin/kotlin-eap" }
     }
     dependencies {
-      classpath 'com.android.tools.build:gradle:3.1.0'
+      classpath 'com.android.tools.build:gradle:3.1.1'
       classpath 'com.google.gms:google-services:3.2.0'
       classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 


### PR DESCRIPTION
Plays a simple animation for cells inheriting the new base adapter class.

### Animation base class
`ChicagoRobotoAdapter` now is used as a base class for `SpeakerAdapter` and `SessionAdapter` which gives the feature to play an animation for views the child adapters show.

They can individually configure the duration or whether or not to play the animation.

`staggerAnimation:Boolean` - Staggers the animations of cells, defaults to `true`
`animationDuration:Long` - The duration of the animation, default to `1000` milliseconds
`showAnimation:Boolean` - Whether to show animation or not, default to `true`

### Kotlin and build tools update
- Updated Kotlin version to `1.2.31`
- Updated Gradle tools to `3.1.1`