### PR TITLE
Fix startup crash on Q

### DIFF
--- a/android/app/src/main/kotlin/com/chicagoroboto/DevconApp.kt
+++ b/android/app/src/main/kotlin/com/chicagoroboto/DevconApp.kt
@@ -18,7 +18,7 @@ class DevconApp() : Application() {
                 .build()
     }
 
-    override fun getSystemService(name: String?): Any {
+    override fun getSystemService(name: String): Any? {
         when (name) {
             "component" -> return component
             else -> return super.getSystemService(name)

--- a/android/app/src/main/kotlin/com/chicagoroboto/features/main/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/chicagoroboto/features/main/MainActivity.kt
@@ -89,7 +89,7 @@ class MainActivity : AppCompatActivity(), SessionNavigator, SpeakerNavigator, Na
         } ?: false
     }
 
-    override fun getSystemService(name: String?): Any {
+    override fun getSystemService(name: String): Any? {
         return when (name) {
             "component" -> component
             else -> super.getSystemService(name)

--- a/android/app/src/main/kotlin/com/chicagoroboto/features/sessiondetail/SessionDetailActivity.kt
+++ b/android/app/src/main/kotlin/com/chicagoroboto/features/sessiondetail/SessionDetailActivity.kt
@@ -22,7 +22,7 @@ class SessionDetailActivity : AppCompatActivity(), SpeakerNavigator {
         session_detail.setSession(sessionId)
     }
 
-    override fun getSystemService(name: String?): Any {
+    override fun getSystemService(name: String): Any? {
         when (name) {
             "component" -> return component
             else -> return super.getSystemService(name)


### PR DESCRIPTION
Method signature of overridden `getSystemService` did not match the framework one. It was being called with a service name of `content_manager`. I have no clue what this is, I can't find anything about it in the SDK source or docs anywhere, but `super.getSystemService()` would return `null` for it, causing this crash:

```
E/AndroidRuntime: FATAL EXCEPTION: main
    Process: com.chicagoroboto, PID: 6847
    java.lang.IllegalStateException: when (name) {
              …emService(name)
            } must not be null
        at com.chicagoroboto.features.main.MainActivity.getSystemService(MainActivity.kt:93)
```