### PR TITLE
Fix Q crash on speaker detail

### DIFF
--- a/android/app/src/main/kotlin/com/chicagoroboto/features/speakerdetail/SpeakerDetailActivity.kt
+++ b/android/app/src/main/kotlin/com/chicagoroboto/features/speakerdetail/SpeakerDetailActivity.kt
@@ -75,7 +75,7 @@ class SpeakerDetailActivity : AppCompatActivity() {
         speaker_detail_view.setSpeakerId(speakerId)
     }
 
-    override fun getSystemService(name: String?): Any {
+    override fun getSystemService(name: String): Any? {
         when (name) {
             "component" -> return component
             else -> return super.getSystemService(name)


### PR DESCRIPTION
I apparently missed fixing one method signature in #33 which causes the speaker detail screen to crash.